### PR TITLE
Add OwnedOrganizations column to the admin user report.

### DIFF
--- a/routes/administration/index.ts
+++ b/routes/administration/index.ts
@@ -53,27 +53,47 @@ router.get('/', (req: ReposAppRequest, res, next) => {
 });
 
 /*
-Returns a CSV of every org and its members, with a column indicating whether the member is linked or not
+Asynchronously returns a CSV file with of each user, the organizations they belong to, and whether they are linked or not
 */
 router.get('/users-report', async (req: ReposAppRequest, res, next) => {
   try {
+    // Use getProviders middleware to obtain operational data, which includes an array of organizations
     const {
       operations: { organizations },
     } = getProviders(req);
     const checks = [];
     const users = {};
 
+    // Loop through each organization in the array
     for (const [orgName, org] of organizations.entries()) {
+      // Get an array of owner logins for the org, which we'll use later
+      const ownerLogins = (await org.getOwners()).map((owner) => owner.login);
+
+      // Push a promise to the checks array, which will be resolved later with a result
       checks.push(
+        // Calling this on an org returns an array of member pairs, each representing a GitHub user who is a member of the org
         org.getUnlinkedAndLinkedMembers().then((memberPairs) => {
+          // Loop through each member pair in the array
           memberPairs.forEach((memberPair) => {
+            // Extract the member object and the link object from the member pair object
             const {
               member: { id: UserId, login: UserLogin },
               link: memberLink,
             } = memberPair;
-            const isLinked = memberLink ? true : false;
-            let userObj = { UserLogin, UserId, Organizations: [], IsLinked: isLinked };
 
+            // Store whether the member is linked or not in a variable
+            const isLinked = memberLink ? true : false;
+
+            // Create an object representing the user; we'll fill it in more later
+            let userObj = {
+              UserLogin,
+              UserId,
+              Organizations: [],
+              OwnedOrganizations: [],
+              IsLinked: isLinked,
+            };
+
+            // If the user is linked, add the fields from the memberLink object to the user object
             if (isLinked) {
               const {
                 corporateId: CorporateId,
@@ -97,19 +117,31 @@ router.get('/users-report', async (req: ReposAppRequest, res, next) => {
 
             users[UserLogin] = users[UserLogin] || userObj;
             users[UserLogin].Organizations.push(orgName);
+
+            if (ownerLogins.includes(UserLogin)) {
+              users[UserLogin].OwnedOrganizations.push(orgName);
+            }
           });
         })
       );
     }
 
+    // Wait for all of the promises in the checks array to be resolved
     await Promise.all(checks);
+    // Define the header row for the CSV
     const header =
-      'UserLogin,UserId,Organizations,IsLinked,CorporateId,CorporateMailAddress,CorporateUsername,CorporateAlias,CorporateDisplayName';
+      'UserLogin,UserId,Organizations,OwnedOrganizations,IsLinked,CorporateId,CorporateMailAddress,CorporateUsername,CorporateAlias,CorporateDisplayName';
+
+    // Sort the users object by user login and convert the values back into an array
     const cleanedObjects: object[] = _.sortBy(Object.values(users), 'UserLogin');
+
+    // Use the json2csvAsync library to convert the cleaned array of user objects into a CSV payload
     const payload = await json2csvAsync(cleanedObjects, { keys: header.split(','), emptyFieldValue: '' });
 
+    // Set up response headers to return a CSV file
     res.header('Content-Type', 'text/csv');
     res.attachment('users-report.csv');
+    // Send the payload as the response body
     res.send(payload);
   } catch (err) {
     next(err);


### PR DESCRIPTION
Includes a list of orgs a user owns in the administrative user report.

Example output:
| UserLogin          | UserId        | Organizations                                                                                                                 | OwnedOrganizations                                                                                                            | IsLinked | CorporateId                              | CorporateMailAddress                        | CorporateUsername | CorporateAlias | CorporateDisplayName |
|--------------------|---------------|-------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|----------|------------------------------------------|--------------------------------------------|-------------------|----------------|----------------------|
| DevOptimusPrime    | 7bde46c02d867 | ["asampleorg","asampleorg-4head","asampleorg-deux","asampleorg-five","asampleorg-six","asampleorg-three","asampleorg-trees"] | ["asampleorg","asampleorg-4head","asampleorg-deux","asampleorg-five","asampleorg-six","asampleorg-three","asampleorg-trees"] | false    |                                          |                                            |                   |                |                      |
| garnertb           | 331146618c69f | ["asampleorg","asampleorg-4head", "asampleorg-five"]                                                                                              | ["asampleorg","asampleorg-4head"]                                                                                              | true     | 0d70ceeff8c034df37917c47d0ab69c3         |                                            |                   | tyler          | Tyler                |